### PR TITLE
Remove completed feature from todo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,3 @@ There's a lot of todo.
 - Make colors chainable
 - Make bold
 - Add truecolor functionality
-- Add support for --no-color and NO_COLOR env variable.


### PR DESCRIPTION
Remove the --no-color and NO_COLOR env variable feature from the TODO section in README.md because this feature was added in v0.2.0.